### PR TITLE
url() is deprecated in Django 4

### DIFF
--- a/hxlti/urls.py
+++ b/hxlti/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r"^launch/", views.lti_landing_page, name="lti_landing"),
+    re_path(r"^launch/", views.lti_landing_page, name="lti_landing"),
 ]


### PR DESCRIPTION
re_path() apparently works basically the same way